### PR TITLE
Fix for forthcoming URI version

### DIFF
--- a/lib/PodCache/Processed.pm6
+++ b/lib/PodCache/Processed.pm6
@@ -493,8 +493,8 @@ unit class PodCache::Processed;
                 $contents = $curl.perform.content;
             }
             when 'file' | '' {
-                if ($uri.path).IO ~~ :f {
-                    $contents = ($uri.path).IO.slurp;
+                if ($uri.path).Str.IO ~~ :f {
+                    $contents = ($uri.path).Str.IO.slurp;
                 }
                 else {
                     $contents = "No file found at ｢$link｣";


### PR DESCRIPTION
This is so the module will continue to work with https://github.com/perl6-community-modules/uri/pull/44
where URI.path will return an object with a Str coercion.

I've tested with both new and as-is versions (it should be a no-op where
.path is a Str.)